### PR TITLE
Refactor: Multi-club support with independent quota tracking

### DIFF
--- a/bot/commands/__init__.py
+++ b/bot/commands/__init__.py
@@ -7,7 +7,9 @@ async def setup(bot):
     from .settings import SettingsCommands
     from .admin import AdminCommands
     from .member import MemberCommands
+    from .club_management import ClubManagementCommands 
     
     await bot.add_cog(SettingsCommands(bot))
     await bot.add_cog(AdminCommands(bot))
     await bot.add_cog(MemberCommands(bot))
+    await bot.add_cog(ClubManagementCommands(bot))  

--- a/bot/commands/club_management.py
+++ b/bot/commands/club_management.py
@@ -1,0 +1,355 @@
+"""
+Club management commands for administrators
+"""
+import discord
+from discord import app_commands
+from discord.ext import commands
+import logging
+from datetime import time
+
+from models import Club
+from config.settings import TIMEZONE
+
+logger = logging.getLogger(__name__)
+
+
+class ClubManagementCommands(commands.Cog):
+    """Commands for managing multiple clubs"""
+    
+    def __init__(self, bot):
+        self.bot = bot
+    
+    @app_commands.command(name="add_club", description="Register a new club (Admin only)")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def add_club(self, interaction: discord.Interaction, 
+                       club_name: str,
+                       circle_id: str,
+                       daily_quota: int = 1000000,
+                       scrape_time: str = "16:00",
+                       timezone: str = "Europe/Amsterdam"):
+        """
+        Add a new club to track
+        
+        Args:
+            club_name: Display name for the club (e.g., "Horsecore")
+            circle_id: ChronoGenesis circle_id from URL
+            daily_quota: Default daily fan quota (default: 1,000,000)
+            scrape_time: Time to scrape in HH:MM format (default: 16:00)
+            timezone: Timezone for schedule (default: Europe/Amsterdam)
+        """
+        await interaction.response.defer()
+        
+        try:
+            # Check if club already exists
+            existing = await Club.get_by_name(club_name)
+            if existing:
+                await interaction.followup.send(f"❌ Club '{club_name}' already exists")
+                return
+            
+            # Build scrape URL
+            scrape_url = f"https://chronogenesis.net/club_profile?circle_id={circle_id}"
+            
+            # Validate scrape time format
+            try:
+                hour, minute = map(int, scrape_time.split(':'))
+                if not (0 <= hour < 24 and 0 <= minute < 60):
+                    raise ValueError
+                # Convert to time object
+                scrape_time_obj = time(hour=hour, minute=minute)
+            except:
+                await interaction.followup.send("❌ Invalid time format. Use HH:MM (e.g., 16:00)")
+                return
+            
+            # Create club
+            club = await Club.create(
+                club_name=club_name,
+                scrape_url=scrape_url,
+                daily_quota=daily_quota,
+                timezone=timezone,
+                scrape_time=scrape_time_obj  # Pass time object, not string
+            )
+            
+            # Format quota
+            if daily_quota >= 1_000_000:
+                quota_formatted = f"{daily_quota / 1_000_000:.1f}M"
+            elif daily_quota >= 1_000:
+                quota_formatted = f"{daily_quota / 1_000:.1f}K"
+            else:
+                quota_formatted = str(daily_quota)
+            
+            embed = discord.Embed(
+                title="✅ Club Added",
+                description=f"Successfully registered **{club_name}**",
+                color=discord.Color.green(),
+                timestamp=discord.utils.utcnow()
+            )
+            
+            embed.add_field(
+                name="Club Details",
+                value=f"**Name:** {club_name}\n"
+                      f"**Circle ID:** {circle_id}\n"
+                      f"**URL:** {scrape_url}",
+                inline=False
+            )
+            
+            embed.add_field(
+                name="Settings",
+                value=f"**Daily Quota:** {quota_formatted} fans\n"
+                      f"**Scrape Time:** {scrape_time} {timezone}\n"
+                      f"**Bomb Rules:** 3 days trigger, 7 days countdown",
+                inline=False
+            )
+            
+            embed.add_field(
+                name="Next Steps",
+                value=f"1. Set channels: `/set_report_channel club:{club_name}` and `/set_alert_channel club:{club_name}`\n"
+                      f"2. Adjust settings: `/edit_club club:{club_name}`\n"
+                      f"3. Manual check: `/force_check club:{club_name}`",
+                inline=False
+            )
+            
+            embed.set_footer(text=f"Added by {interaction.user}")
+            
+            await interaction.followup.send(embed=embed)
+            logger.info(f"Club '{club_name}' added by {interaction.user}")
+            
+        except Exception as e:
+            logger.error(f"Error in add_club: {e}", exc_info=True)
+            await interaction.followup.send(f"❌ Error: {str(e)}")
+    
+    @app_commands.command(name="remove_club", description="Deactivate a club (Admin only)")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def remove_club(self, interaction: discord.Interaction, club: str):
+        """Deactivate a club (data is preserved)"""
+        await interaction.response.defer()
+        
+        try:
+            club_obj = await Club.get_by_name(club)
+            
+            if not club_obj:
+                await interaction.followup.send(f"❌ Club '{club}' not found")
+                return
+            
+            if not club_obj.is_active:
+                await interaction.followup.send(f"ℹ️ Club '{club}' is already deactivated")
+                return
+            
+            await club_obj.deactivate()
+            
+            embed = discord.Embed(
+                title="✅ Club Deactivated",
+                description=f"**{club}** has been deactivated",
+                color=discord.Color.orange(),
+                timestamp=discord.utils.utcnow()
+            )
+            
+            embed.add_field(
+                name="ℹ️ What this means",
+                value="• Daily scraping stopped\n"
+                      "• Member data preserved\n"
+                      "• Can be reactivated with `/activate_club`",
+                inline=False
+            )
+            
+            embed.set_footer(text=f"Deactivated by {interaction.user}")
+            
+            await interaction.followup.send(embed=embed)
+            logger.info(f"Club '{club}' deactivated by {interaction.user}")
+            
+        except Exception as e:
+            logger.error(f"Error in remove_club: {e}", exc_info=True)
+            await interaction.followup.send(f"❌ Error: {str(e)}")
+    
+    @app_commands.command(name="activate_club", description="Reactivate a club (Admin only)")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def activate_club(self, interaction: discord.Interaction, club: str):
+        """Reactivate a deactivated club"""
+        await interaction.response.defer()
+        
+        try:
+            club_obj = await Club.get_by_name(club)
+            
+            if not club_obj:
+                await interaction.followup.send(f"❌ Club '{club}' not found")
+                return
+            
+            if club_obj.is_active:
+                await interaction.followup.send(f"ℹ️ Club '{club}' is already active")
+                return
+            
+            await club_obj.activate()
+            
+            embed = discord.Embed(
+                title="✅ Club Reactivated",
+                description=f"**{club}** has been reactivated",
+                color=discord.Color.green(),
+                timestamp=discord.utils.utcnow()
+            )
+            
+            embed.add_field(
+                name="ℹ️ What's next",
+                value="Daily scraping will resume at the scheduled time.",
+                inline=False
+            )
+            
+            embed.set_footer(text=f"Reactivated by {interaction.user}")
+            
+            await interaction.followup.send(embed=embed)
+            logger.info(f"Club '{club}' reactivated by {interaction.user}")
+            
+        except Exception as e:
+            logger.error(f"Error in activate_club: {e}", exc_info=True)
+            await interaction.followup.send(f"❌ Error: {str(e)}")
+    
+    @app_commands.command(name="list_clubs", description="View all registered clubs")
+    async def list_clubs(self, interaction: discord.Interaction):
+        """List all clubs"""
+        await interaction.response.defer()
+        
+        try:
+            clubs = await Club.get_all()
+            
+            if not clubs:
+                await interaction.followup.send("No clubs registered yet. Use `/add_club` to add one.")
+                return
+            
+            embed = discord.Embed(
+                title="🏆 Registered Clubs",
+                description=f"Total: {len(clubs)} club{'s' if len(clubs) != 1 else ''}",
+                color=discord.Color.blue(),
+                timestamp=discord.utils.utcnow()
+            )
+            
+            for club in clubs:
+                status = "✅ Active" if club.is_active else "❌ Inactive"
+                
+                # Format quota
+                if club.daily_quota >= 1_000_000:
+                    quota_formatted = f"{club.daily_quota / 1_000_000:.1f}M"
+                elif club.daily_quota >= 1_000:
+                    quota_formatted = f"{club.daily_quota / 1_000:.1f}K"
+                else:
+                    quota_formatted = str(club.daily_quota)
+                
+                embed.add_field(
+                    name=f"{status} {club.club_name}",
+                    value=f"**Quota:** {quota_formatted} fans/day\n"
+                          f"**Schedule:** {club.get_scrape_time_str()} {club.timezone}\n"
+                          f"**URL:** [ChronoGenesis]({club.scrape_url})",
+                    inline=False
+                )
+            
+            await interaction.followup.send(embed=embed)
+            
+        except Exception as e:
+            logger.error(f"Error in list_clubs: {e}", exc_info=True)
+            await interaction.followup.send(f"❌ Error: {str(e)}")
+    
+    @app_commands.command(name="edit_club", description="Edit club settings (Admin only)")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def edit_club(self, interaction: discord.Interaction, 
+                       club: str,
+                       daily_quota: int = None,
+                       scrape_time: str = None,
+                       timezone: str = None,
+                       bomb_trigger_days: int = None,
+                       bomb_countdown_days: int = None):
+        """Edit club configuration"""
+        await interaction.response.defer()
+        
+        try:
+            club_obj = await Club.get_by_name(club)
+            
+            if not club_obj:
+                await interaction.followup.send(f"❌ Club '{club}' not found")
+                return
+            
+            updates = {}
+            if daily_quota is not None:
+                updates['daily_quota'] = daily_quota
+            if scrape_time is not None:
+                # Validate and convert to time object
+                try:
+                    hour, minute = map(int, scrape_time.split(':'))
+                    if not (0 <= hour < 24 and 0 <= minute < 60):
+                        raise ValueError
+                    updates['scrape_time'] = time(hour=hour, minute=minute)
+                except:
+                    await interaction.followup.send("❌ Invalid time format. Use HH:MM (e.g., 16:00)")
+                    return
+            if timezone is not None:
+                updates['timezone'] = timezone
+            if bomb_trigger_days is not None:
+                updates['bomb_trigger_days'] = bomb_trigger_days
+            if bomb_countdown_days is not None:
+                updates['bomb_countdown_days'] = bomb_countdown_days
+            
+            if not updates:
+                await interaction.followup.send("❌ No changes specified")
+                return
+            
+            await club_obj.update_settings(**updates)
+            
+            embed = discord.Embed(
+                title="✅ Club Settings Updated",
+                description=f"Successfully updated **{club}**",
+                color=discord.Color.green(),
+                timestamp=discord.utils.utcnow()
+            )
+            
+            changes_text = []
+            for key, value in updates.items():
+                if key == 'daily_quota':
+                    if value >= 1_000_000:
+                        formatted = f"{value / 1_000_000:.1f}M"
+                    elif value >= 1_000:
+                        formatted = f"{value / 1_000:.1f}K"
+                    else:
+                        formatted = str(value)
+                    changes_text.append(f"**Daily Quota:** {formatted} fans")
+                elif key == 'scrape_time':
+                    changes_text.append(f"**Scrape Time:** {value}")
+                elif key == 'timezone':
+                    changes_text.append(f"**Timezone:** {value}")
+                elif key == 'bomb_trigger_days':
+                    changes_text.append(f"**Bomb Trigger:** {value} days")
+                elif key == 'bomb_countdown_days':
+                    changes_text.append(f"**Bomb Countdown:** {value} days")
+            
+            embed.add_field(
+                name="Changes Applied",
+                value="\n".join(changes_text),
+                inline=False
+            )
+            
+            embed.set_footer(text=f"Updated by {interaction.user}")
+            
+            await interaction.followup.send(embed=embed)
+            logger.info(f"Club '{club}' settings updated by {interaction.user}: {updates}")
+            
+        except Exception as e:
+            logger.error(f"Error in edit_club: {e}", exc_info=True)
+            await interaction.followup.send(f"❌ Error: {str(e)}")
+    
+    # Autocomplete for club parameter
+    async def club_autocomplete(self, interaction: discord.Interaction, current: str):
+        """Autocomplete for club names"""
+        try:
+            club_names = await Club.get_all_names()
+            return [
+                app_commands.Choice(name=name, value=name)
+                for name in club_names
+                if current.lower() in name.lower()
+            ][:25]
+        except:
+            return []
+    
+    # Add autocomplete to commands
+    remove_club.autocomplete('club')(club_autocomplete)
+    activate_club.autocomplete('club')(club_autocomplete)
+    edit_club.autocomplete('club')(club_autocomplete)
+
+
+async def setup(bot):
+    """Setup function for loading the cog"""
+    await bot.add_cog(ClubManagementCommands(bot))

--- a/bot/commands/settings.py
+++ b/bot/commands/settings.py
@@ -6,11 +6,9 @@ from discord import app_commands
 from discord.ext import commands
 from datetime import datetime
 import logging
-import pytz
 
-from models import BotSettings
+from models import Club
 from services import MonthlyInfoService
-from config.settings import TIMEZONE
 
 logger = logging.getLogger(__name__)
 
@@ -21,26 +19,43 @@ class SettingsCommands(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.monthly_info_service = MonthlyInfoService()
-        self.timezone = pytz.timezone(TIMEZONE)
+    
+    async def club_autocomplete(self, interaction: discord.Interaction, current: str):
+        """Autocomplete for club names"""
+        try:
+            club_names = await Club.get_all_names()
+            return [
+                app_commands.Choice(name=name, value=name)
+                for name in club_names
+                if current.lower() in name.lower()
+            ][:25]
+        except Exception as e:
+            logger.error(f"Error in club autocomplete: {e}")
+            return []
     
     @app_commands.command(name="set_report_channel", description="Set the channel for daily reports")
     @app_commands.checks.has_permissions(administrator=True)
-    async def set_report_channel(self, interaction: discord.Interaction, channel: discord.TextChannel):
+    async def set_report_channel(self, interaction: discord.Interaction, channel: discord.TextChannel, club: str):
         """Set the channel where daily reports will be posted"""
         await interaction.response.defer()
         
         try:
-            await BotSettings.set_report_channel_id(channel.id)
+            club_obj = await Club.get_by_name(club)
+            if not club_obj:
+                await interaction.followup.send(f"❌ Club '{club}' not found")
+                return
+            
+            await club_obj.set_channels(report_channel_id=channel.id)
             
             embed = discord.Embed(
-                title="✅ Report Channel Updated",
+                title=f"✅ Report Channel Updated - {club}",
                 description=f"Daily reports will now be posted to {channel.mention}",
                 color=discord.Color.green(),
                 timestamp=discord.utils.utcnow()
             )
             
             await interaction.followup.send(embed=embed)
-            logger.info(f"Report channel set to {channel.name} ({channel.id}) by {interaction.user}")
+            logger.info(f"Report channel for {club} set to {channel.name} ({channel.id}) by {interaction.user}")
             
         except Exception as e:
             logger.error(f"Error in set_report_channel: {e}", exc_info=True)
@@ -48,22 +63,27 @@ class SettingsCommands(commands.Cog):
     
     @app_commands.command(name="set_alert_channel", description="Set the channel for alerts (bombs, kicks)")
     @app_commands.checks.has_permissions(administrator=True)
-    async def set_alert_channel(self, interaction: discord.Interaction, channel: discord.TextChannel):
+    async def set_alert_channel(self, interaction: discord.Interaction, channel: discord.TextChannel, club: str):
         """Set the channel where alerts will be posted"""
         await interaction.response.defer()
         
         try:
-            await BotSettings.set_alert_channel_id(channel.id)
+            club_obj = await Club.get_by_name(club)
+            if not club_obj:
+                await interaction.followup.send(f"❌ Club '{club}' not found")
+                return
+            
+            await club_obj.set_channels(alert_channel_id=channel.id)
             
             embed = discord.Embed(
-                title="✅ Alert Channel Updated",
+                title=f"✅ Alert Channel Updated - {club}",
                 description=f"Alerts (bomb warnings, kick notifications) will now be posted to {channel.mention}",
                 color=discord.Color.green(),
                 timestamp=discord.utils.utcnow()
             )
             
             await interaction.followup.send(embed=embed)
-            logger.info(f"Alert channel set to {channel.name} ({channel.id}) by {interaction.user}")
+            logger.info(f"Alert channel for {club} set to {channel.name} ({channel.id}) by {interaction.user}")
             
         except Exception as e:
             logger.error(f"Error in set_alert_channel: {e}", exc_info=True)
@@ -71,64 +91,57 @@ class SettingsCommands(commands.Cog):
     
     @app_commands.command(name="channel_settings", description="View current channel configuration")
     @app_commands.checks.has_permissions(administrator=True)
-    async def channel_settings(self, interaction: discord.Interaction):
+    async def channel_settings(self, interaction: discord.Interaction, club: str):
         """View current channel settings"""
         await interaction.response.defer()
         
         try:
-            report_channel_id = await BotSettings.get_report_channel_id()
-            alert_channel_id = await BotSettings.get_alert_channel_id()
+            club_obj = await Club.get_by_name(club)
+            if not club_obj:
+                await interaction.followup.send(f"❌ Club '{club}' not found")
+                return
             
             embed = discord.Embed(
-                title="⚙️ Channel Settings",
+                title=f"⚙️ Channel Settings - {club}",
                 color=discord.Color.blue(),
                 timestamp=discord.utils.utcnow()
             )
             
             # Report channel
-            if report_channel_id:
-                report_channel = self.bot.get_channel(report_channel_id)
+            if club_obj.report_channel_id:
+                report_channel = self.bot.get_channel(club_obj.report_channel_id)
                 if report_channel:
                     embed.add_field(
                         name="📊 Daily Reports Channel",
-                        value=f"{report_channel.mention} (ID: {report_channel_id})",
+                        value=f"{report_channel.mention} (ID: {club_obj.report_channel_id})",
                         inline=False
                     )
                 else:
                     embed.add_field(
                         name="📊 Daily Reports Channel",
-                        value=f"⚠️ Channel not found (ID: {report_channel_id})",
+                        value=f"⚠️ Channel not found (ID: {club_obj.report_channel_id})",
                         inline=False
                     )
             else:
-                from config.settings import CHANNEL_ID
-                if CHANNEL_ID:
-                    channel = self.bot.get_channel(CHANNEL_ID)
-                    embed.add_field(
-                        name="📊 Daily Reports Channel",
-                        value=f"Using .env fallback: {channel.mention if channel else f'ID: {CHANNEL_ID}'}",
-                        inline=False
-                    )
-                else:
-                    embed.add_field(
-                        name="📊 Daily Reports Channel",
-                        value="❌ Not configured",
-                        inline=False
-                    )
+                embed.add_field(
+                    name="📊 Daily Reports Channel",
+                    value="❌ Not configured",
+                    inline=False
+                )
             
             # Alert channel
-            if alert_channel_id:
-                alert_channel = self.bot.get_channel(alert_channel_id)
+            if club_obj.alert_channel_id:
+                alert_channel = self.bot.get_channel(club_obj.alert_channel_id)
                 if alert_channel:
                     embed.add_field(
                         name="🚨 Alerts Channel",
-                        value=f"{alert_channel.mention} (ID: {alert_channel_id})",
+                        value=f"{alert_channel.mention} (ID: {club_obj.alert_channel_id})",
                         inline=False
                     )
                 else:
                     embed.add_field(
                         name="🚨 Alerts Channel",
-                        value=f"⚠️ Channel not found (ID: {alert_channel_id})",
+                        value=f"⚠️ Channel not found (ID: {club_obj.alert_channel_id})",
                         inline=False
                     )
             else:
@@ -148,57 +161,50 @@ class SettingsCommands(commands.Cog):
     
     @app_commands.command(name="post_monthly_info", description="Post the monthly info board (auto-updates)")
     @app_commands.checks.has_permissions(administrator=True)
-    async def post_monthly_info(self, interaction: discord.Interaction, channel: discord.TextChannel = None):
+    async def post_monthly_info(self, interaction: discord.Interaction, club: str, channel: discord.TextChannel = None):
         """Post or update the monthly information board"""
         await interaction.response.defer()
         
         try:
+            club_obj = await Club.get_by_name(club)
+            if not club_obj:
+                await interaction.followup.send(f"❌ Club '{club}' not found")
+                return
+            
             # Use current channel if none specified
             target_channel = channel or interaction.channel
             
-            # Get current date
-            current_datetime = datetime.now(self.timezone)
+            # Get current date in club's timezone
+            import pytz
+            club_tz = pytz.timezone(club_obj.timezone)
+            current_datetime = datetime.now(club_tz)
             current_date = current_datetime.date()
             
             # Generate embed
             embed = await self.monthly_info_service.create_monthly_info_embed(current_date)
+            embed.title = f"📋 Monthly Info Board - {club_obj.club_name}"
+            embed.set_footer(text=f"This message auto-updates when quota changes • {club_obj.club_name}")
             
-            # Check if monthly info already exists
-            existing_message_id = await BotSettings.get_monthly_info_message_id()
-            existing_channel_id = await BotSettings.get_monthly_info_channel_id()
-            
-            if existing_message_id and existing_channel_id:
-                # Try to update existing message
-                try:
-                    existing_channel = self.bot.get_channel(existing_channel_id)
-                    if existing_channel:
-                        existing_message = await existing_channel.fetch_message(existing_message_id)
-                        await existing_message.edit(embed=embed)
-                        
-                        await interaction.followup.send(
-                            f"✅ Updated existing monthly info board in {existing_channel.mention}"
-                        )
-                        return
-                except (discord.NotFound, discord.Forbidden):
-                    logger.warning(f"Could not find/edit existing monthly info message")
-            
-            # Post new message
+            # Post message
             message = await target_channel.send(embed=embed)
-            
-            # Save location
-            await BotSettings.set_monthly_info_location(target_channel.id, message.id)
             
             embed_response = discord.Embed(
                 title="✅ Monthly Info Board Posted",
-                description=f"Posted in {target_channel.mention}\n\n"
+                description=f"Posted in {target_channel.mention} for **{club_obj.club_name}**\n\n"
                            f"This message will auto-update when quota changes.",
                 color=discord.Color.green(),
                 timestamp=discord.utils.utcnow()
             )
             
             await interaction.followup.send(embed=embed_response)
-            logger.info(f"Monthly info board posted in {target_channel.name} by {interaction.user}")
+            logger.info(f"Monthly info board posted for {club_obj.club_name} in {target_channel.name} by {interaction.user}")
             
         except Exception as e:
             logger.error(f"Error in post_monthly_info: {e}", exc_info=True)
             await interaction.followup.send(f"❌ Error: {str(e)}")
+    
+    # Apply autocomplete
+    set_report_channel.autocomplete('club')(club_autocomplete)
+    set_alert_channel.autocomplete('club')(club_autocomplete)
+    channel_settings.autocomplete('club')(club_autocomplete)
+    post_monthly_info.autocomplete('club')(club_autocomplete)

--- a/bot/tasks.py
+++ b/bot/tasks.py
@@ -3,15 +3,14 @@ Scheduled tasks for the Discord bot
 """
 import discord
 from discord.ext import tasks
-from datetime import datetime, time, date as date_class
+from datetime import datetime
 import logging
 import pytz
 import asyncio
 
-from config.settings import CHANNEL_ID, TIMEZONE, DAILY_REPORT_TIME, SCRAPE_URL
+from models import Club, Member
 from scrapers import ChronoGenesisScraper
-from services import QuotaCalculator, BombManager, ReportGenerator, NotificationService
-from models import Member, BotSettings
+from services import QuotaCalculator, BombManager, ReportGenerator, NotificationService, ScrapeLockManager, ScrapeContext
 
 logger = logging.getLogger(__name__)
 
@@ -21,27 +20,20 @@ class BotTasks:
     
     def __init__(self, bot):
         self.bot = bot
-        self.scraper = ChronoGenesisScraper(SCRAPE_URL)
         self.quota_calculator = QuotaCalculator()
         self.bomb_manager = BombManager()
         self.report_generator = ReportGenerator()
         self.notification_service = NotificationService(bot)
-        self.timezone = pytz.timezone(TIMEZONE)
         
-        # Parse daily report time
-        hour, minute = map(int, DAILY_REPORT_TIME.split(':'))
-        self.target_hour = hour
-        self.target_minute = minute
+        # Track last run per club per day (club_id_YYYY-MM-DD -> True)
+        self.last_runs = {}
         
-        # Track last run date to prevent duplicate runs
-        self.last_run_date = None
-        
-        logger.info(f"Tasks configured to run daily at {DAILY_REPORT_TIME} {TIMEZONE}")
+        logger.info("Multi-club tasks configured - will check all clubs hourly")
     
     def start_tasks(self):
         """Start all scheduled tasks"""
         self.hourly_check.start()
-        logger.info("Scheduled tasks started (checking hourly for target time)")
+        logger.info("Scheduled tasks started (checking all clubs hourly)")
     
     def stop_tasks(self):
         """Stop all scheduled tasks"""
@@ -50,221 +42,271 @@ class BotTasks:
     
     @tasks.loop(hours=1)
     async def hourly_check(self):
-        """Check every hour if it's time to run the daily report"""
-        now = datetime.now(self.timezone)
-        current_date = now.date()
+        """Check every hour if it's time to run any club's daily report"""
+        logger.info("=" * 80)
+        logger.info("Hourly check - scanning all clubs...")
+        logger.info("=" * 80)
         
-        if now.hour == self.target_hour and now.minute >= self.target_minute:
-            if self.last_run_date == current_date:
-                logger.debug(f"Daily check already completed today ({current_date})")
-                return
+        try:
+            # Get all active clubs
+            clubs = await Club.get_all_active()
+            logger.info(f"Found {len(clubs)} active club(s)")
             
-            logger.info(f"⏰ Target time reached ({now.strftime('%H:%M')} {TIMEZONE}), starting daily check...")
-            self.last_run_date = current_date
-            await self.daily_check()
-    
-    async def daily_check(self):
-        """Daily quota check and report generation with error recovery"""
-        logger.info("=" * 60)
-        logger.info("Starting daily check...")
-        logger.info("=" * 60)
-        
-        # Get channels
-        report_channel_id = await BotSettings.get_report_channel_id()
-        alert_channel_id = await BotSettings.get_alert_channel_id()
-        
-        if not report_channel_id:
-            report_channel_id = CHANNEL_ID
-        
-        if not alert_channel_id:
-            alert_channel_id = report_channel_id
-        
-        report_channel = self.bot.get_channel(report_channel_id)
-        alert_channel = self.bot.get_channel(alert_channel_id)
-        
-        if not report_channel:
-            logger.error(f"Report channel {report_channel_id} not found")
-            return
-        
-        if not alert_channel:
-            logger.warning(f"Alert channel {alert_channel_id} not found, using report channel")
-            alert_channel = report_channel
-        
-        current_datetime = datetime.now(self.timezone)
-        current_date = current_datetime.date()
-        
-        # Retry configuration
-        max_retries = 3
-        retry_delay = 10
-        
-        scraped_data = None
-        current_day = None
-        last_error = None
-        
-        # STEP 1: Try to scrape with retries
-        for attempt in range(1, max_retries + 1):
-            try:
-                logger.info(f"🔍 Scraping attempt {attempt}/{max_retries}...")
-                scraped_data = await self.scraper.scrape()
-                current_day = self.scraper.get_current_day()
-                
-                if scraped_data:
-                    logger.info(f"✅ Scraping successful on attempt {attempt} ({len(scraped_data)} members found)")
-                    break
-                else:
-                    raise ValueError("Scraper returned empty data")
+            for club in clubs:
+                try:
+                    # Convert current time to club's timezone
+                    club_tz = pytz.timezone(club.timezone)
+                    now_in_club_tz = datetime.now(club_tz)
+                    current_date = now_in_club_tz.date()
                     
-            except Exception as e:
-                last_error = e
-                logger.error(f"❌ Scraping failed (attempt {attempt}/{max_retries}): {e}")
+                    # Get target time for this club
+                    target_hour = club.scrape_time.hour
+                    target_minute = club.scrape_time.minute
+                    
+                    # Check if it's time to scrape
+                    if (now_in_club_tz.hour == target_hour and 
+                        now_in_club_tz.minute >= target_minute):
+                        
+                        # Check if already ran today
+                        run_key = f"{club.club_id}_{current_date}"
+                        if self.last_runs.get(run_key):
+                            logger.debug(f"{club.club_name}: Already ran today ({current_date})")
+                            continue
+                        
+                        logger.info(f"⏰ Time to check {club.club_name} ({now_in_club_tz.strftime('%H:%M')} {club.timezone})")
+                        
+                        # Mark as running
+                        self.last_runs[run_key] = True
+                        
+                        # Run check for this club (non-blocking)
+                        asyncio.create_task(self.daily_check_for_club(club))
+                    else:
+                        logger.debug(f"{club.club_name}: Not time yet (current: {now_in_club_tz.strftime('%H:%M')}, target: {target_hour:02d}:{target_minute:02d} {club.timezone})")
                 
-                if attempt < max_retries:
-                    logger.info(f"Retrying in {retry_delay} seconds...")
-                    await asyncio.sleep(retry_delay)
-                    retry_delay *= 2
+                except Exception as e:
+                    logger.error(f"Error checking club {club.club_name}: {e}", exc_info=True)
+                    continue
         
-        # STEP 2: Handle scraping failure
-        if not scraped_data:
-            error_msg = (
-                f"Failed to scrape data after {max_retries} attempts.\n\n"
-                f"**Last error:** {str(last_error)}\n\n"
-                f"**Possible causes:**\n"
-                f"• Website is down or blocked\n"
-                f"• Cookie consent popup changed\n"
-                f"• Network timeout\n"
-                f"• Website structure changed"
-            )
-            logger.error(error_msg)
-            
-            error_embed = self.report_generator.create_error_report(error_msg)
-            await report_channel.send(embed=error_embed)
-            await report_channel.send(
-                "⚠️ **Manual intervention required!**\n"
-                "Administrators can run `/force_check` to retry manually."
-            )
-            return
-        
-        # STEP 3: Process the scraped data
-        try:
-            logger.info("⚙️ Processing scraped data...")
-            new_members, updated_members = await self.quota_calculator.process_scraped_data(
-                scraped_data, current_date, current_day
-            )
-            
-            logger.info(f"✅ Data processed: {updated_members} members updated, {new_members} new members")
-            
         except Exception as e:
-            logger.error(f"❌ Error processing scraped data: {e}", exc_info=True)
-            error_embed = self.report_generator.create_error_report(
-                f"Data processing failed: {str(e)}"
-            )
-            await report_channel.send(embed=error_embed)
-            return
+            logger.error(f"Error in hourly_check: {e}", exc_info=True)
+    
+    async def daily_check_for_club(self, club: Club):
+        """Daily quota check and report generation for a specific club"""
+        logger.info("=" * 80)
+        logger.info(f"Starting daily check for {club.club_name}")
+        logger.info("=" * 80)
         
-        # STEP 4: Bomb management
         try:
-            logger.info("💣 Checking for bomb activations...")
-            newly_activated_bombs = await self.bomb_manager.check_and_activate_bombs(current_date)
-            
-            logger.info("⏳ Updating bomb countdowns...")
-            await self.bomb_manager.update_bomb_countdowns(current_date)
-            
-            logger.info("✅ Checking for bomb deactivations...")
-            deactivated_bombs = await self.bomb_manager.check_and_deactivate_bombs(current_date)
-            
-            logger.info("🚨 Checking for expired bombs...")
-            members_to_kick = await self.bomb_manager.check_expired_bombs()
-            
-            logger.info(f"Bomb management complete: {len(newly_activated_bombs)} activated, "
-                       f"{len(deactivated_bombs)} deactivated, {len(members_to_kick)} to kick")
-            
-        except Exception as e:
-            logger.error(f"❌ Error during bomb management: {e}", exc_info=True)
-            newly_activated_bombs = []
-            deactivated_bombs = []
-            members_to_kick = []
-        
-        # STEP 5: Send DM notifications to linked users
-        try:
-            if newly_activated_bombs:
-                logger.info("📨 Sending bomb activation DMs to linked users...")
-                await self.notification_service.send_bomb_notifications(newly_activated_bombs)
-            
-            if deactivated_bombs:
-                logger.info("📨 Sending bomb deactivation DMs to linked users...")
-                for item in deactivated_bombs:
-                    member = item['member']
-                    await self.notification_service.send_bomb_deactivation_notification(member)
-            
-            # Send deficit notifications
-            status_summary = await self.quota_calculator.get_member_status_summary(current_date)
-            if status_summary['behind']:
-                logger.info("📨 Sending deficit notifications to linked users...")
-                await self.notification_service.send_deficit_notifications(status_summary['behind'])
-            
-        except Exception as e:
-            logger.error(f"❌ Error sending DM notifications: {e}", exc_info=True)
-        
-        # STEP 6: Generate and send reports
-        try:
-            logger.info("📊 Generating daily report...")
-            status_summary = await self.quota_calculator.get_member_status_summary(current_date)
-            bombs_data = await self.bomb_manager.get_active_bombs_with_members()
-            
-            daily_reports = self.report_generator.create_daily_report(
-                status_summary, bombs_data, current_date
-            )
-            
-            for embed in daily_reports:
-                await report_channel.send(embed=embed)
-            
-            logger.info(f"✅ Daily report sent ({len(daily_reports)} embed(s))")
-            
-            # Send bomb deactivation report if any
-            if deactivated_bombs:
-                deactivation_embed = self.report_generator.create_bomb_deactivation_report(deactivated_bombs)
-                await report_channel.send(embed=deactivation_embed)
-                logger.info(f"✅ Bomb deactivation report sent ({len(deactivated_bombs)} member(s))")
-            
-        except Exception as e:
-            logger.error(f"❌ Error generating/sending daily report: {e}", exc_info=True)
-            error_embed = self.report_generator.create_error_report(
-                f"Failed to generate daily report: {str(e)}"
-            )
-            await report_channel.send(embed=error_embed)
-        
-        # STEP 7: Send alerts to alert channel
-        try:
-            if newly_activated_bombs:
-                bomb_data = []
-                for bomb in newly_activated_bombs:
-                    member = await Member.get_by_id(bomb.member_id)
-                    bomb_data.append({'bomb': bomb, 'member': member})
+            # Use scrape lock to prevent conflicts
+            async with ScrapeContext(club.club_id, f"tasks_{club.club_name}"):
+                # Get channels
+                report_channel = self.bot.get_channel(club.report_channel_id)
+                alert_channel = self.bot.get_channel(club.alert_channel_id or club.report_channel_id)
                 
-                alert_embed = self.report_generator.create_bomb_activation_alert(bomb_data)
-                await alert_channel.send(embed=alert_embed)
-                logger.info(f"💣 Sent bomb activation alert for {len(bomb_data)} member(s)")
-            
-            if members_to_kick:
-                kick_embed = self.report_generator.create_kick_alert(members_to_kick)
-                await alert_channel.send(embed=kick_embed)
-                logger.info(f"🚨 Sent kick alert for {len(members_to_kick)} member(s)")
-            
-        except Exception as e:
-            logger.error(f"❌ Error sending alerts: {e}", exc_info=True)
+                if not report_channel:
+                    logger.error(f"Report channel {club.report_channel_id} not found for {club.club_name}")
+                    return
+                
+                if not alert_channel:
+                    logger.warning(f"Alert channel not found for {club.club_name}, using report channel")
+                    alert_channel = report_channel
+                
+                # Get current date in club's timezone
+                club_tz = pytz.timezone(club.timezone)
+                current_datetime = datetime.now(club_tz)
+                current_date = current_datetime.date()
+                
+                # Retry configuration
+                max_retries = 3
+                retry_delay = 10
+                
+                scraped_data = None
+                current_day = None
+                last_error = None
+                
+                # STEP 1: Try to scrape with retries
+                scraper = ChronoGenesisScraper(club.scrape_url)
+                
+                for attempt in range(1, max_retries + 1):
+                    try:
+                        logger.info(f"🔍 Scraping {club.club_name} (attempt {attempt}/{max_retries})...")
+                        scraped_data = await scraper.scrape()
+                        current_day = scraper.get_current_day()
+                        
+                        if scraped_data:
+                            logger.info(f"✅ Scraping successful for {club.club_name} ({len(scraped_data)} members found)")
+                            break
+                        else:
+                            raise ValueError("Scraper returned empty data")
+                            
+                    except Exception as e:
+                        last_error = e
+                        logger.error(f"❌ Scraping failed for {club.club_name} (attempt {attempt}/{max_retries}): {e}")
+                        
+                        if attempt < max_retries:
+                            logger.info(f"Retrying in {retry_delay} seconds...")
+                            await asyncio.sleep(retry_delay)
+                            retry_delay *= 2
+                
+                # STEP 2: Handle scraping failure
+                if not scraped_data:
+                    error_msg = (
+                        f"Failed to scrape data after {max_retries} attempts.\n\n"
+                        f"**Last error:** {str(last_error)}\n\n"
+                        f"**Possible causes:**\n"
+                        f"• Website is down or blocked\n"
+                        f"• Cookie consent popup changed\n"
+                        f"• Network timeout\n"
+                        f"• Website structure changed"
+                    )
+                    logger.error(f"Scraping failed for {club.club_name}: {error_msg}")
+                    
+                    error_embed = self.report_generator.create_error_report(club.club_name, error_msg)
+                    await report_channel.send(embed=error_embed)
+                    await report_channel.send(
+                        f"⚠️ **Manual intervention required for {club.club_name}!**\n"
+                        f"Administrators can run `/force_check club:{club.club_name}` to retry manually."
+                    )
+                    return
+                
+                # STEP 3: Process the scraped data
+                try:
+                    logger.info(f"⚙️ Processing scraped data for {club.club_name}...")
+                    new_members, updated_members = await self.quota_calculator.process_scraped_data(
+                        club.club_id, scraped_data, current_date, current_day
+                    )
+                    
+                    logger.info(f"✅ Data processed for {club.club_name}: {updated_members} members updated, {new_members} new members")
+                    
+                except Exception as e:
+                    logger.error(f"❌ Error processing scraped data for {club.club_name}: {e}", exc_info=True)
+                    error_embed = self.report_generator.create_error_report(
+                        club.club_name,
+                        f"Data processing failed: {str(e)}"
+                    )
+                    await report_channel.send(embed=error_embed)
+                    return
+                
+                # STEP 4: Bomb management
+                try:
+                    logger.info(f"💣 Checking for bomb activations in {club.club_name}...")
+                    newly_activated_bombs = await self.bomb_manager.check_and_activate_bombs(club, current_date)
+                    
+                    logger.info(f"⏳ Updating bomb countdowns for {club.club_name}...")
+                    await self.bomb_manager.update_bomb_countdowns(club.club_id, current_date)
+                    
+                    logger.info(f"✅ Checking for bomb deactivations in {club.club_name}...")
+                    deactivated_bombs = await self.bomb_manager.check_and_deactivate_bombs(club.club_id, current_date)
+                    
+                    logger.info(f"🚨 Checking for expired bombs in {club.club_name}...")
+                    members_to_kick = await self.bomb_manager.check_expired_bombs(club.club_id)
+                    
+                    logger.info(f"Bomb management complete for {club.club_name}: {len(newly_activated_bombs)} activated, "
+                               f"{len(deactivated_bombs)} deactivated, {len(members_to_kick)} to kick")
+                    
+                except Exception as e:
+                    logger.error(f"❌ Error during bomb management for {club.club_name}: {e}", exc_info=True)
+                    newly_activated_bombs = []
+                    deactivated_bombs = []
+                    members_to_kick = []
+                
+                # STEP 5: Send DM notifications to linked users
+                try:
+                    if newly_activated_bombs:
+                        logger.info(f"📨 Sending bomb activation DMs for {club.club_name}...")
+                        await self.notification_service.send_bomb_notifications(club.club_name, newly_activated_bombs)
+                    
+                    if deactivated_bombs:
+                        logger.info(f"📨 Sending bomb deactivation DMs for {club.club_name}...")
+                        for item in deactivated_bombs:
+                            member = item['member']
+                            await self.notification_service.send_bomb_deactivation_notification(club.club_name, member)
+                    
+                    # Send deficit notifications
+                    status_summary = await self.quota_calculator.get_member_status_summary(club.club_id, current_date)
+                    if status_summary['behind']:
+                        logger.info(f"📨 Sending deficit notifications for {club.club_name}...")
+                        await self.notification_service.send_deficit_notifications(club.club_name, status_summary['behind'])
+                    
+                except Exception as e:
+                    logger.error(f"❌ Error sending DM notifications for {club.club_name}: {e}", exc_info=True)
+                
+                # STEP 6: Generate and send reports
+                try:
+                    logger.info(f"📊 Generating daily report for {club.club_name}...")
+                    status_summary = await self.quota_calculator.get_member_status_summary(club.club_id, current_date)
+                    bombs_data = await self.bomb_manager.get_active_bombs_with_members(club.club_id)
+                    
+                    daily_reports = self.report_generator.create_daily_report(
+                        club.club_name, club.daily_quota, status_summary, bombs_data, current_date
+                    )
+                    
+                    for embed in daily_reports:
+                        await report_channel.send(embed=embed)
+                    
+                    logger.info(f"✅ Daily report sent for {club.club_name} ({len(daily_reports)} embed(s))")
+                    
+                    # Send bomb deactivation report if any
+                    if deactivated_bombs:
+                        deactivation_embed = self.report_generator.create_bomb_deactivation_report(club.club_name, deactivated_bombs)
+                        await report_channel.send(embed=deactivation_embed)
+                        logger.info(f"✅ Bomb deactivation report sent for {club.club_name} ({len(deactivated_bombs)} member(s))")
+                    
+                except Exception as e:
+                    logger.error(f"❌ Error generating/sending daily report for {club.club_name}: {e}", exc_info=True)
+                    error_embed = self.report_generator.create_error_report(
+                        club.club_name,
+                        f"Failed to generate daily report: {str(e)}"
+                    )
+                    await report_channel.send(embed=error_embed)
+                
+                # STEP 7: Send alerts to alert channel
+                try:
+                    if newly_activated_bombs:
+                        bomb_data = []
+                        for bomb in newly_activated_bombs:
+                            member = await Member.get_by_id(bomb.member_id)
+                            bomb_data.append({'bomb': bomb, 'member': member})
+                        
+                        alert_embed = self.report_generator.create_bomb_activation_alert(club.club_name, bomb_data)
+                        await alert_channel.send(embed=alert_embed)
+                        logger.info(f"💣 Sent bomb activation alert for {club.club_name} ({len(bomb_data)} member(s))")
+                    
+                    if members_to_kick:
+                        kick_embed = self.report_generator.create_kick_alert(club.club_name, members_to_kick)
+                        await alert_channel.send(embed=kick_embed)
+                        logger.info(f"🚨 Sent kick alert for {club.club_name} ({len(members_to_kick)} member(s))")
+                    
+                except Exception as e:
+                    logger.error(f"❌ Error sending alerts for {club.club_name}: {e}", exc_info=True)
+                
+                # STEP 8: Final summary
+                logger.info("=" * 80)
+                logger.info(f"✅ Daily check complete for {club.club_name}!")
+                logger.info(f"   • Members updated: {updated_members}")
+                logger.info(f"   • New members: {new_members}")
+                logger.info(f"   • Bombs activated: {len(newly_activated_bombs)}")
+                logger.info(f"   • Bombs deactivated: {len(deactivated_bombs)}")
+                logger.info(f"   • Members to kick: {len(members_to_kick)}")
+                logger.info("=" * 80)
         
-        # STEP 8: Final summary
-        logger.info("=" * 60)
-        logger.info(f"✅ Daily check complete!")
-        logger.info(f"   • Members updated: {updated_members}")
-        logger.info(f"   • New members: {new_members}")
-        logger.info(f"   • Bombs activated: {len(newly_activated_bombs)}")
-        logger.info(f"   • Bombs deactivated: {len(deactivated_bombs)}")
-        logger.info(f"   • Members to kick: {len(members_to_kick)}")
-        logger.info("=" * 60)
+        except Exception as e:
+            logger.error(f"Fatal error in daily check for {club.club_name}: {e}", exc_info=True)
+            
+            # Try to send error notification
+            try:
+                report_channel = self.bot.get_channel(club.report_channel_id)
+                if report_channel:
+                    error_embed = self.report_generator.create_error_report(
+                        club.club_name,
+                        f"Fatal error during daily check: {str(e)}"
+                    )
+                    await report_channel.send(embed=error_embed)
+            except:
+                pass
     
     @hourly_check.before_loop
     async def before_hourly_check(self):
         """Wait for bot to be ready before starting tasks"""
         await self.bot.wait_until_ready()
-        logger.info(f"Bot ready, will check hourly for {DAILY_REPORT_TIME} {TIMEZONE}")
+        logger.info("Bot ready, multi-club hourly check loop starting")

--- a/config/database.py
+++ b/config/database.py
@@ -56,15 +56,33 @@ class Database:
             return await conn.fetchval(query, *args)
     
     async def initialize_schema(self):
-        """Initialize database schema"""
+        """Initialize database schema with multi-club support"""
         schema_sql = """
         -- Enable UUID extension
         CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
         
+        -- Clubs table (NEW for multi-club support)
+        CREATE TABLE IF NOT EXISTS clubs (
+            club_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+            club_name VARCHAR(100) UNIQUE NOT NULL,
+            scrape_url TEXT NOT NULL,
+            daily_quota BIGINT NOT NULL DEFAULT 1000000,
+            timezone VARCHAR(100) NOT NULL DEFAULT 'Europe/Amsterdam',
+            scrape_time TIME NOT NULL DEFAULT '16:00',
+            bomb_trigger_days INTEGER NOT NULL DEFAULT 3,
+            bomb_countdown_days INTEGER NOT NULL DEFAULT 7,
+            is_active BOOLEAN DEFAULT TRUE,
+            report_channel_id BIGINT,
+            alert_channel_id BIGINT,
+            created_at TIMESTAMPTZ DEFAULT NOW(),
+            updated_at TIMESTAMPTZ DEFAULT NOW()
+        );
+        
         -- Members table
         CREATE TABLE IF NOT EXISTS members (
             member_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-            trainer_id VARCHAR(50) UNIQUE,
+            club_id UUID NOT NULL REFERENCES clubs(club_id) ON DELETE CASCADE,
+            trainer_id VARCHAR(50),
             trainer_name VARCHAR(100) NOT NULL,
             join_date DATE NOT NULL,
             is_active BOOLEAN DEFAULT TRUE,
@@ -73,6 +91,18 @@ class Database:
             created_at TIMESTAMPTZ DEFAULT NOW(),
             updated_at TIMESTAMPTZ DEFAULT NOW()
         );
+        
+        -- Migration: Add club_id column if it doesn't exist
+        DO $$ 
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns 
+                WHERE table_name='members' AND column_name='club_id'
+            ) THEN
+                ALTER TABLE members ADD COLUMN club_id UUID REFERENCES clubs(club_id) ON DELETE CASCADE;
+                RAISE NOTICE 'Added club_id column to members';
+            END IF;
+        END $$;
         
         -- Migration: Add trainer_id column if it doesn't exist
         DO $$ 
@@ -98,34 +128,11 @@ class Database:
             END IF;
         END $$;
         
-        -- Migration: Remove UNIQUE constraint from trainer_name if it exists
-        DO $$
-        BEGIN
-            IF EXISTS (
-                SELECT 1 FROM pg_constraint 
-                WHERE conname = 'members_trainer_name_key'
-            ) THEN
-                ALTER TABLE members DROP CONSTRAINT members_trainer_name_key;
-                RAISE NOTICE 'Removed UNIQUE constraint from trainer_name';
-            END IF;
-        END $$;
-        
-        -- Migration: Add UNIQUE constraint to trainer_id if it doesn't exist
-        DO $$
-        BEGIN
-            IF NOT EXISTS (
-                SELECT 1 FROM pg_constraint 
-                WHERE conname = 'members_trainer_id_key'
-            ) THEN
-                ALTER TABLE members ADD CONSTRAINT members_trainer_id_key UNIQUE (trainer_id);
-                RAISE NOTICE 'Added UNIQUE constraint to trainer_id';
-            END IF;
-        END $$;
-        
         -- Quota history table
         CREATE TABLE IF NOT EXISTS quota_history (
             id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
             member_id UUID NOT NULL REFERENCES members(member_id) ON DELETE CASCADE,
+            club_id UUID NOT NULL REFERENCES clubs(club_id) ON DELETE CASCADE,
             date DATE NOT NULL,
             cumulative_fans BIGINT NOT NULL,
             expected_fans BIGINT NOT NULL,
@@ -135,10 +142,23 @@ class Database:
             UNIQUE(member_id, date)
         );
         
+        -- Migration: Add club_id to quota_history if it doesn't exist
+        DO $$ 
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns 
+                WHERE table_name='quota_history' AND column_name='club_id'
+            ) THEN
+                ALTER TABLE quota_history ADD COLUMN club_id UUID REFERENCES clubs(club_id) ON DELETE CASCADE;
+                RAISE NOTICE 'Added club_id column to quota_history';
+            END IF;
+        END $$;
+        
         -- Bombs table
         CREATE TABLE IF NOT EXISTS bombs (
             bomb_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
             member_id UUID NOT NULL REFERENCES members(member_id) ON DELETE CASCADE,
+            club_id UUID NOT NULL REFERENCES clubs(club_id) ON DELETE CASCADE,
             activation_date DATE NOT NULL,
             days_remaining INTEGER NOT NULL,
             is_active BOOLEAN DEFAULT TRUE,
@@ -160,24 +180,62 @@ class Database:
             END IF;
         END $$;
         
+        -- Migration: Add club_id to bombs if it doesn't exist
+        DO $$ 
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns 
+                WHERE table_name='bombs' AND column_name='club_id'
+            ) THEN
+                ALTER TABLE bombs ADD COLUMN club_id UUID REFERENCES clubs(club_id) ON DELETE CASCADE;
+                RAISE NOTICE 'Added club_id column to bombs';
+            END IF;
+        END $$;
+        
         -- Quota requirements table
         CREATE TABLE IF NOT EXISTS quota_requirements (
             id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+            club_id UUID NOT NULL REFERENCES clubs(club_id) ON DELETE CASCADE,
             effective_date DATE NOT NULL,
             daily_quota BIGINT NOT NULL,
             set_by VARCHAR(100),
             created_at TIMESTAMPTZ DEFAULT NOW()
         );
         
+        -- Migration: Add club_id to quota_requirements if it doesn't exist
+        DO $$ 
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns 
+                WHERE table_name='quota_requirements' AND column_name='club_id'
+            ) THEN
+                ALTER TABLE quota_requirements ADD COLUMN club_id UUID REFERENCES clubs(club_id) ON DELETE CASCADE;
+                RAISE NOTICE 'Added club_id column to quota_requirements';
+            END IF;
+        END $$;
+        
         -- Scrape history table
         CREATE TABLE IF NOT EXISTS scrape_history (
             scrape_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+            club_id UUID NOT NULL REFERENCES clubs(club_id) ON DELETE CASCADE,
             scrape_date TIMESTAMPTZ NOT NULL,
             success BOOLEAN NOT NULL,
             error_message TEXT,
             members_scraped INTEGER,
             created_at TIMESTAMPTZ DEFAULT NOW()
         );
+        
+        -- Migration: Add club_id to scrape_history if it doesn't exist
+        DO $$ 
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns 
+                WHERE table_name='scrape_history' AND column_name='club_id'
+            ) THEN
+                ALTER TABLE scrape_history ADD COLUMN club_id UUID REFERENCES clubs(club_id) ON DELETE CASCADE;
+                RAISE NOTICE 'Added club_id column to scrape_history';
+            END IF;
+        END $$;
         
         -- Bot settings table
         CREATE TABLE IF NOT EXISTS bot_settings (
@@ -197,7 +255,18 @@ class Database:
             updated_at TIMESTAMPTZ DEFAULT NOW()
         );
         
+        -- Scrape locks table (for preventing concurrent scrapes)
+        CREATE TABLE IF NOT EXISTS scrape_locks (
+            club_id UUID PRIMARY KEY REFERENCES clubs(club_id) ON DELETE CASCADE,
+            locked_at TIMESTAMPTZ NOT NULL,
+            locked_by VARCHAR(100) NOT NULL
+        );
+        
         -- Indexes for performance
+        CREATE INDEX IF NOT EXISTS idx_members_club_id ON members(club_id);
+        CREATE INDEX IF NOT EXISTS idx_quota_history_club_id ON quota_history(club_id);
+        CREATE INDEX IF NOT EXISTS idx_bombs_club_id ON bombs(club_id);
+        CREATE INDEX IF NOT EXISTS idx_quota_requirements_club_id ON quota_requirements(club_id);
         CREATE INDEX IF NOT EXISTS idx_quota_history_member_date 
             ON quota_history(member_id, date DESC);
         CREATE INDEX IF NOT EXISTS idx_bombs_active 
@@ -210,12 +279,17 @@ class Database:
             ON quota_requirements(effective_date DESC);
         CREATE INDEX IF NOT EXISTS idx_user_links_member_id
             ON user_links(member_id);
+        
+        -- Unique constraint for trainer_id per club
+        DROP INDEX IF EXISTS members_trainer_id_key;
+        CREATE UNIQUE INDEX IF NOT EXISTS members_trainer_id_club_unique 
+            ON members(trainer_id, club_id) WHERE trainer_id IS NOT NULL;
         """
         
         try:
             async with self.pool.acquire() as conn:
                 await conn.execute(schema_sql)
-            logger.info("Database schema initialized successfully")
+            logger.info("Database schema initialized successfully with multi-club support")
         except Exception as e:
             logger.error(f"Failed to initialize schema: {e}")
             raise

--- a/config/settings.py
+++ b/config/settings.py
@@ -21,7 +21,7 @@ SCRAPE_RETRY_DELAY = 1  # seconds
 
 # Timezone Configuration
 TIMEZONE = "Europe/Amsterdam"  # CEST
-DAILY_REPORT_TIME = "13:00"
+DAILY_REPORT_TIME = "16:00"
 
 # Quota Rules
 DAILY_QUOTA = 1_000_000

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -7,5 +7,6 @@ from .bomb import Bomb
 from .quota_requirement import QuotaRequirement
 from .bot_settings import BotSettings
 from .user_link import UserLink
+from .club import Club
 
-__all__ = ['Member', 'QuotaHistory', 'Bomb', 'QuotaRequirement', 'BotSettings', 'UserLink']
+__all__ = ['Member', 'QuotaHistory', 'Bomb', 'QuotaRequirement', 'BotSettings', 'UserLink', 'Club']

--- a/models/club.py
+++ b/models/club.py
@@ -1,0 +1,193 @@
+"""
+Club data model for multi-club support
+"""
+from dataclasses import dataclass
+from datetime import time
+from typing import Optional, List
+from uuid import UUID
+import logging
+
+from config.database import db
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Club:
+    """Represents a club configuration"""
+    club_id: UUID
+    club_name: str
+    scrape_url: str
+    daily_quota: int
+    timezone: str
+    scrape_time: time
+    bomb_trigger_days: int
+    bomb_countdown_days: int
+    is_active: bool
+    report_channel_id: Optional[int]
+    alert_channel_id: Optional[int]
+    created_at: Optional[str]
+    updated_at: Optional[str]
+    
+    @classmethod
+    async def create(cls, club_name: str, scrape_url: str, daily_quota: int = 1000000,
+                     timezone: str = 'Europe/Amsterdam', scrape_time: time = None,
+                     bomb_trigger_days: int = 3, bomb_countdown_days: int = 7) -> 'Club':
+        """Create a new club"""
+        # Default scrape time if not provided
+        if scrape_time is None:
+            scrape_time = time(16, 0)  # 16:00
+        
+        query = """
+            INSERT INTO clubs (club_name, scrape_url, daily_quota, timezone, scrape_time, 
+                             bomb_trigger_days, bomb_countdown_days)
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            RETURNING club_id, club_name, scrape_url, daily_quota, timezone, scrape_time,
+                     bomb_trigger_days, bomb_countdown_days, is_active, report_channel_id,
+                     alert_channel_id, created_at, updated_at
+        """
+        row = await db.fetchrow(query, club_name, scrape_url, daily_quota, timezone, 
+                                scrape_time, bomb_trigger_days, bomb_countdown_days)
+        logger.info(f"Created new club: {club_name}")
+        return cls(**dict(row))
+    
+    @classmethod
+    async def get_by_id(cls, club_id: UUID) -> Optional['Club']:
+        """Get club by ID"""
+        query = """
+            SELECT club_id, club_name, scrape_url, daily_quota, timezone, scrape_time,
+                   bomb_trigger_days, bomb_countdown_days, is_active, report_channel_id,
+                   alert_channel_id, created_at, updated_at
+            FROM clubs
+            WHERE club_id = $1
+        """
+        row = await db.fetchrow(query, club_id)
+        if row:
+            return cls(**dict(row))
+        return None
+    
+    @classmethod
+    async def get_by_name(cls, club_name: str) -> Optional['Club']:
+        """Get club by name"""
+        query = """
+            SELECT club_id, club_name, scrape_url, daily_quota, timezone, scrape_time,
+                   bomb_trigger_days, bomb_countdown_days, is_active, report_channel_id,
+                   alert_channel_id, created_at, updated_at
+            FROM clubs
+            WHERE club_name = $1
+        """
+        row = await db.fetchrow(query, club_name)
+        if row:
+            return cls(**dict(row))
+        return None
+    
+    @classmethod
+    async def get_all_active(cls) -> List['Club']:
+        """Get all active clubs"""
+        query = """
+            SELECT club_id, club_name, scrape_url, daily_quota, timezone, scrape_time,
+                   bomb_trigger_days, bomb_countdown_days, is_active, report_channel_id,
+                   alert_channel_id, created_at, updated_at
+            FROM clubs
+            WHERE is_active = TRUE
+            ORDER BY club_name
+        """
+        rows = await db.fetch(query)
+        return [cls(**dict(row)) for row in rows]
+    
+    @classmethod
+    async def get_all(cls) -> List['Club']:
+        """Get all clubs (active and inactive)"""
+        query = """
+            SELECT club_id, club_name, scrape_url, daily_quota, timezone, scrape_time,
+                   bomb_trigger_days, bomb_countdown_days, is_active, report_channel_id,
+                   alert_channel_id, created_at, updated_at
+            FROM clubs
+            ORDER BY club_name
+        """
+        rows = await db.fetch(query)
+        return [cls(**dict(row)) for row in rows]
+    
+    @classmethod
+    async def get_all_names(cls) -> List[str]:
+        """Get all active club names for autocomplete"""
+        query = """
+            SELECT club_name
+            FROM clubs
+            WHERE is_active = TRUE
+            ORDER BY club_name
+        """
+        rows = await db.fetch(query)
+        return [row['club_name'] for row in rows]
+    
+    async def update_settings(self, **kwargs):
+        """Update club settings"""
+        valid_fields = {'scrape_url', 'daily_quota', 'timezone', 'scrape_time', 
+                       'bomb_trigger_days', 'bomb_countdown_days', 'report_channel_id',
+                       'alert_channel_id'}
+        
+        updates = {k: v for k, v in kwargs.items() if k in valid_fields}
+        if not updates:
+            return
+        
+        # Convert scrape_time string to time object if needed
+        if 'scrape_time' in updates and isinstance(updates['scrape_time'], str):
+            from datetime import time as time_class
+            hour, minute = map(int, updates['scrape_time'].split(':'))
+            updates['scrape_time'] = time_class(hour=hour, minute=minute)
+        
+        set_clause = ', '.join([f"{k} = ${i+2}" for i, k in enumerate(updates.keys())])
+        values = [self.club_id] + list(updates.values())
+        
+        query = f"""
+            UPDATE clubs
+            SET {set_clause}, updated_at = NOW()
+            WHERE club_id = $1
+        """
+        await db.execute(query, *values)
+        
+        for k, v in updates.items():
+            setattr(self, k, v)
+        
+        logger.info(f"Updated club settings for {self.club_name}: {updates}")
+    
+    async def set_channels(self, report_channel_id: Optional[int] = None, 
+                          alert_channel_id: Optional[int] = None):
+        """Set report and alert channels"""
+        query = """
+            UPDATE clubs
+            SET report_channel_id = $2, alert_channel_id = $3, updated_at = NOW()
+            WHERE club_id = $1
+        """
+        await db.execute(query, self.club_id, report_channel_id, alert_channel_id)
+        self.report_channel_id = report_channel_id
+        self.alert_channel_id = alert_channel_id
+        logger.info(f"Updated channels for {self.club_name}")
+    
+    async def deactivate(self):
+        """Deactivate club"""
+        query = """
+            UPDATE clubs
+            SET is_active = FALSE, updated_at = NOW()
+            WHERE club_id = $1
+        """
+        await db.execute(query, self.club_id)
+        self.is_active = False
+        logger.info(f"Deactivated club: {self.club_name}")
+    
+    async def activate(self):
+        """Activate club"""
+        query = """
+            UPDATE clubs
+            SET is_active = TRUE, updated_at = NOW()
+            WHERE club_id = $1
+        """
+        await db.execute(query, self.club_id)
+        self.is_active = True
+        logger.info(f"Activated club: {self.club_name}")
+    
+    def get_scrape_time_str(self) -> str:
+        """Get scrape time as HH:MM string"""
+        if isinstance(self.scrape_time, time):
+            return self.scrape_time.strftime('%H:%M')
+        return str(self.scrape_time)

--- a/models/quota_requirement.py
+++ b/models/quota_requirement.py
@@ -16,55 +16,59 @@ logger = logging.getLogger(__name__)
 class QuotaRequirement:
     """Represents a quota requirement setting"""
     id: Optional[UUID]
+    club_id: UUID
     effective_date: date
     daily_quota: int
     set_by: Optional[str]
     
     @classmethod
-    async def create(cls, effective_date: date, daily_quota: int, set_by: str = None) -> 'QuotaRequirement':
+    async def create(cls, club_id: UUID, effective_date: date, daily_quota: int, set_by: str = None) -> 'QuotaRequirement':
         """Create a new quota requirement"""
         query = """
-            INSERT INTO quota_requirements (effective_date, daily_quota, set_by)
-            VALUES ($1, $2, $3)
-            RETURNING id, effective_date, daily_quota, set_by
+            INSERT INTO quota_requirements (club_id, effective_date, daily_quota, set_by)
+            VALUES ($1, $2, $3, $4)
+            RETURNING id, club_id, effective_date, daily_quota, set_by
         """
-        row = await db.fetchrow(query, effective_date, daily_quota, set_by)
-        logger.info(f"Quota requirement created: {daily_quota:,} fans/day effective {effective_date} (set by {set_by})")
+        row = await db.fetchrow(query, club_id, effective_date, daily_quota, set_by)
+        logger.info(f"Quota requirement created for club {club_id}: {daily_quota:,} fans/day effective {effective_date} (set by {set_by})")
         return cls(**dict(row))
     
     @classmethod
-    async def get_quota_for_date(cls, check_date: date) -> int:
+    async def get_quota_for_date(cls, club_id: UUID, check_date: date) -> int:
         """
-        Get the applicable daily quota for a specific date
+        Get the applicable daily quota for a specific date in a club
         
         Args:
+            club_id: Club UUID
             check_date: The date to check
         
         Returns:
-            The daily quota amount (defaults to DAILY_QUOTA from settings if none found)
+            The daily quota amount (defaults to club's default quota if none found)
         """
         query = """
             SELECT daily_quota
             FROM quota_requirements
-            WHERE effective_date <= $1
+            WHERE club_id = $1 AND effective_date <= $2
             ORDER BY effective_date DESC
             LIMIT 1
         """
-        result = await db.fetchval(query, check_date)
+        result = await db.fetchval(query, club_id, check_date)
         
         if result is not None:
             return result
         
-        # No quota requirement found, use default from settings
-        from config.settings import DAILY_QUOTA
-        return DAILY_QUOTA
+        # No quota requirement found, use club's default quota
+        from models import Club
+        club = await Club.get_by_id(club_id)
+        return club.daily_quota if club else 1000000
     
     @classmethod
-    async def get_all_for_month(cls, year: int, month: int) -> List['QuotaRequirement']:
+    async def get_all_for_month(cls, club_id: UUID, year: int, month: int) -> List['QuotaRequirement']:
         """
-        Get all quota requirements for a specific month
+        Get all quota requirements for a specific month in a club
         
         Args:
+            club_id: Club UUID
             year: Year (e.g., 2024)
             month: Month (1-12)
         
@@ -81,22 +85,22 @@ class QuotaRequirement:
             end_date = date_class(year, month + 1, 1)
         
         query = """
-            SELECT id, effective_date, daily_quota, set_by
+            SELECT id, club_id, effective_date, daily_quota, set_by
             FROM quota_requirements
-            WHERE effective_date >= $1 AND effective_date < $2
+            WHERE club_id = $1 AND effective_date >= $2 AND effective_date < $3
             ORDER BY effective_date ASC
         """
-        rows = await db.fetch(query, start_date, end_date)
+        rows = await db.fetch(query, club_id, start_date, end_date)
         return [cls(**dict(row)) for row in rows]
     
     @classmethod
-    async def get_all_current_month(cls, current_date: date) -> List['QuotaRequirement']:
-        """Get all quota requirements for the current month"""
-        return await cls.get_all_for_month(current_date.year, current_date.month)
+    async def get_all_current_month(cls, club_id: UUID, current_date: date) -> List['QuotaRequirement']:
+        """Get all quota requirements for the current month in a club"""
+        return await cls.get_all_for_month(club_id, current_date.year, current_date.month)
     
     @classmethod
-    async def clear_all(cls):
-        """Clear all quota requirements (for monthly reset)"""
-        query = "DELETE FROM quota_requirements"
-        await db.execute(query)
-        logger.info("Cleared all quota requirements for monthly reset")
+    async def clear_all(cls, club_id: UUID):
+        """Clear all quota requirements for a club (for monthly reset)"""
+        query = "DELETE FROM quota_requirements WHERE club_id = $1"
+        await db.execute(query, club_id)
+        logger.info(f"Cleared all quota requirements for club {club_id} (monthly reset)")

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -6,5 +6,14 @@ from .bomb_manager import BombManager
 from .report_generator import ReportGenerator
 from .notification_service import NotificationService
 from .monthly_info_service import MonthlyInfoService
+from .scrape_lock_manager import ScrapeLockManager, ScrapeContext
 
-__all__ = ['QuotaCalculator', 'BombManager', 'ReportGenerator', 'NotificationService', 'MonthlyInfoService']
+__all__ = [
+    'QuotaCalculator', 
+    'BombManager', 
+    'ReportGenerator', 
+    'NotificationService', 
+    'MonthlyInfoService',
+    'ScrapeLockManager',
+    'ScrapeContext'
+]

--- a/services/notification_service.py
+++ b/services/notification_service.py
@@ -17,7 +17,7 @@ class NotificationService:
     def __init__(self, bot):
         self.bot = bot
     
-    async def send_bomb_notifications(self, newly_activated_bombs: List):
+    async def send_bomb_notifications(self, club_name: str, newly_activated_bombs: List):
         """Send DM notifications to users whose bombs were just activated"""
         user_links = await UserLink.get_all_with_bomb_notifications()
         
@@ -38,7 +38,7 @@ class NotificationService:
                 user = await self.bot.fetch_user(user_link.discord_user_id)
                 
                 embed = discord.Embed(
-                    title="💣 Bomb Activated!",
+                    title=f"💣 Bomb Activated - {club_name}",
                     description=f"Your trainer **{member.trainer_name}** has been behind quota for 3 consecutive days.",
                     color=COLOR_BOMB,
                     timestamp=discord.utils.utcnow()
@@ -66,17 +66,17 @@ class NotificationService:
                     inline=False
                 )
                 
-                embed.set_footer(text="Use /my_status to check your progress • /notification_settings to manage alerts")
+                embed.set_footer(text=f"Use /my_status to check your progress • {club_name}")
                 
                 await user.send(embed=embed)
-                logger.info(f"Sent bomb notification to Discord user {user_link.discord_user_id} for {member.trainer_name}")
+                logger.info(f"Sent bomb notification to Discord user {user_link.discord_user_id} for {member.trainer_name} in {club_name}")
                 
             except discord.Forbidden:
                 logger.warning(f"Cannot send DM to user {user_link.discord_user_id} (DMs disabled)")
             except Exception as e:
                 logger.error(f"Error sending bomb notification to {user_link.discord_user_id}: {e}")
     
-    async def send_deficit_notifications(self, members_data: List[Dict]):
+    async def send_deficit_notifications(self, club_name: str, members_data: List[Dict]):
         """Send DM notifications to users who are behind quota (once per day)"""
         user_links = await UserLink.get_all_with_deficit_notifications()
         
@@ -104,7 +104,7 @@ class NotificationService:
                 deficit = abs(history.deficit_surplus)
                 
                 embed = discord.Embed(
-                    title="⚠️ Behind Quota",
+                    title=f"⚠️ Behind Quota - {club_name}",
                     description=f"Your trainer **{member.trainer_name}** is currently behind quota.",
                     color=COLOR_BEHIND,
                     timestamp=discord.utils.utcnow()
@@ -141,17 +141,17 @@ class NotificationService:
                         inline=False
                     )
                 
-                embed.set_footer(text="Use /my_status to check progress • /notification_settings to disable these alerts")
+                embed.set_footer(text=f"Use /my_status to check progress • {club_name}")
                 
                 await user.send(embed=embed)
-                logger.info(f"Sent deficit notification to Discord user {user_link.discord_user_id} for {member.trainer_name}")
+                logger.info(f"Sent deficit notification to Discord user {user_link.discord_user_id} for {member.trainer_name} in {club_name}")
                 
             except discord.Forbidden:
                 logger.warning(f"Cannot send DM to user {user_link.discord_user_id} (DMs disabled)")
             except Exception as e:
                 logger.error(f"Error sending deficit notification to {user_link.discord_user_id}: {e}")
     
-    async def send_bomb_deactivation_notification(self, member: Member):
+    async def send_bomb_deactivation_notification(self, club_name: str, member: Member):
         """Send notification when a bomb is deactivated"""
         user_link = await UserLink.get_by_member_id(member.member_id)
         
@@ -162,7 +162,7 @@ class NotificationService:
             user = await self.bot.fetch_user(user_link.discord_user_id)
             
             embed = discord.Embed(
-                title="✅ Bomb Deactivated!",
+                title=f"✅ Bomb Deactivated - {club_name}",
                 description=f"Congratulations! Your trainer **{member.trainer_name}** is back on track!",
                 color=discord.Color.green(),
                 timestamp=discord.utils.utcnow()
@@ -184,10 +184,10 @@ class NotificationService:
                 inline=False
             )
             
-            embed.set_footer(text="Use /my_status to check your progress")
+            embed.set_footer(text=f"Use /my_status to check your progress • {club_name}")
             
             await user.send(embed=embed)
-            logger.info(f"Sent bomb deactivation notification to Discord user {user_link.discord_user_id}")
+            logger.info(f"Sent bomb deactivation notification to Discord user {user_link.discord_user_id} for {club_name}")
             
         except discord.Forbidden:
             logger.warning(f"Cannot send DM to user {user_link.discord_user_id} (DMs disabled)")

--- a/services/quota_calculator.py
+++ b/services/quota_calculator.py
@@ -1,26 +1,28 @@
 """
-Quota calculation service
+Quota calculation service with multi-club support
 """
 from datetime import date, timedelta
 from typing import Dict, List, Tuple, Set
+from uuid import UUID
 import logging
 
-from models import Member, QuotaHistory, QuotaRequirement, Bomb
-from config.settings import DAILY_QUOTA
+from models import Member, QuotaHistory, QuotaRequirement, Bomb, Club
 from config.database import db
 
 logger = logging.getLogger(__name__)
 
 
 class QuotaCalculator:
-    """Handles all quota calculations and tracking"""
+    """Handles all quota calculations and tracking per club"""
     
     @staticmethod
-    async def calculate_expected_fans(join_day: int, current_day: int, current_date: date) -> int:
+    async def calculate_expected_fans(club_id: UUID, join_day: int, current_day: int, 
+                                     current_date: date) -> int:
         """
         Calculate expected cumulative fans based on days active and quota history
         
         Args:
+            club_id: Club UUID
             join_day: What day of the month they joined (1-31)
             current_day: Current day of the month (1-31)
             current_date: Current date object
@@ -35,45 +37,32 @@ class QuotaCalculator:
         
         # Calculate for each day the member was active
         for day in range(join_day, current_day + 1):
-            # Get the date for this day
             day_date = date(current_date.year, current_date.month, day)
             
-            # Get the quota that was in effect on that day
-            daily_quota = await QuotaRequirement.get_quota_for_date(day_date)
+            # Get the quota that was in effect on that day for this club
+            daily_quota = await QuotaRequirement.get_quota_for_date(club_id, day_date)
             total_expected += daily_quota
         
         return total_expected
     
     @staticmethod
     def calculate_days_active_in_month(join_day: int, current_day: int) -> int:
-        """
-        Calculate how many days a member has been active this month
-        
-        Args:
-            join_day: What day of the month they joined (1-31)
-            current_day: Current day of the month (1-31)
-        
-        Returns:
-            Number of days active (inclusive of both join and current day)
-        """
+        """Calculate how many days a member has been active this month"""
         if join_day > current_day:
             return 0
-        
         return current_day - join_day + 1
     
     @staticmethod
     def calculate_deficit_surplus(actual_fans: int, expected_fans: int) -> int:
-        """
-        Calculate deficit or surplus
-        
-        Returns:
-            Positive = surplus, Negative = deficit
-        """
+        """Calculate deficit or surplus (positive = surplus, negative = deficit)"""
         return actual_fans - expected_fans
     
-    async def _get_previous_cumulative_totals(self) -> Dict[str, int]:
+    async def _get_previous_cumulative_totals(self, club_id: UUID) -> Dict[str, int]:
         """
         Get the latest cumulative fan counts from database for monthly reset detection
+        
+        Args:
+            club_id: Club UUID
         
         Returns:
             Dict mapping trainer_id/name -> cumulative_fans
@@ -82,9 +71,11 @@ class QuotaCalculator:
             SELECT m.trainer_id, m.trainer_name, qh.cumulative_fans
             FROM members m
             JOIN quota_history qh ON m.member_id = qh.member_id
-            WHERE qh.date = (SELECT MAX(date) FROM quota_history)
+            WHERE m.club_id = $1 AND qh.date = (
+                SELECT MAX(date) FROM quota_history WHERE club_id = $1
+            )
         """
-        rows = await db.fetch(query)
+        rows = await db.fetch(query, club_id)
         
         result = {}
         for row in rows:
@@ -97,13 +88,6 @@ class QuotaCalculator:
                                            previous_totals: Dict[str, int]) -> bool:
         """
         Detect if a monthly reset has occurred by comparing scraped data to previous totals
-        
-        Args:
-            scraped_data: Dict of trainer_id -> {name, trainer_id, fans[], join_day}
-            previous_totals: Dict of trainer_id/name -> previous cumulative fans
-        
-        Returns:
-            True if monthly reset detected, False otherwise
         """
         if not previous_totals:
             logger.info("No previous data found, skipping reset detection")
@@ -130,24 +114,15 @@ class QuotaCalculator:
         
         return False
     
-    async def _auto_deactivate_missing_members(self, scraped_trainer_ids: Set[str]):
-        """
-        Auto-deactivate members who are no longer in the scraped data
-        
-        Args:
-            scraped_trainer_ids: Set of trainer_ids (or names) from scraped data
-        """
-        # Get all currently active members
-        active_members = await Member.get_all_active()
+    async def _auto_deactivate_missing_members(self, club_id: UUID, scraped_trainer_ids: Set[str]):
+        """Auto-deactivate members who are no longer in the scraped data"""
+        active_members = await Member.get_all_active(club_id)
         
         deactivated_count = 0
         for member in active_members:
-            # Use trainer_id if available, otherwise use name
             member_key = member.trainer_id if member.trainer_id else member.trainer_name
             
-            # If this member is not in the scraped data, they've left the club
             if member_key not in scraped_trainer_ids:
-                # UPDATED: Pass manual=False for auto-deactivation
                 await member.deactivate(manual=False)
                 deactivated_count += 1
                 logger.info(f"Auto-deactivated member (no longer in club): {member.trainer_name}")
@@ -155,39 +130,44 @@ class QuotaCalculator:
         if deactivated_count > 0:
             logger.info(f"Auto-deactivated {deactivated_count} member(s) who left the club")
     
-    async def process_scraped_data(self, scraped_data: Dict[str, Dict], 
+    async def process_scraped_data(self, club_id: UUID, scraped_data: Dict[str, Dict], 
                                    current_date: date, current_day: int) -> Tuple[int, int]:
         """
-        Process scraped data and update database
+        Process scraped data and update database for a specific club
         
         Args:
+            club_id: Club UUID
             scraped_data: Dict of trainer_id -> {name, trainer_id, fans[], join_day}
             current_date: Current date
-            current_day: Current day number in the month (from scraper)
+            current_day: Current day number in the month
         
         Returns:
             Tuple of (new_members_count, updated_members_count)
         """
-        # STEP 1: Check for monthly reset FIRST
-        logger.info("Checking for monthly reset...")
-        previous_totals = await self._get_previous_cumulative_totals()
+        # Check for monthly reset
+        logger.info(f"Checking for monthly reset for club {club_id}...")
+        previous_totals = await self._get_previous_cumulative_totals(club_id)
         
         if self._detect_monthly_reset_from_scraped(scraped_data, previous_totals):
-            logger.warning("Monthly reset detected! Clearing all history...")
-            await QuotaHistory.clear_all()
-            await Bomb.clear_all()
-            await QuotaRequirement.clear_all()
+            logger.warning(f"Monthly reset detected for club {club_id}! Clearing all history...")
             
-            # UPDATED: Clear manual deactivation flags on monthly reset
-            query = "UPDATE members SET manually_deactivated = FALSE WHERE manually_deactivated = TRUE"
-            await db.execute(query)
-            logger.info("Monthly reset complete - cleared manual deactivation flags")
+            # Clear club-specific data
+            await db.execute("DELETE FROM quota_history WHERE club_id = $1", club_id)
+            await db.execute("DELETE FROM bombs WHERE club_id = $1", club_id)
+            await db.execute("DELETE FROM quota_requirements WHERE club_id = $1", club_id)
+            
+            # Clear manual deactivation flags for this club
+            await db.execute(
+                "UPDATE members SET manually_deactivated = FALSE WHERE club_id = $1 AND manually_deactivated = TRUE",
+                club_id
+            )
+            logger.info(f"Monthly reset complete for club {club_id}")
         
-        # STEP 2: Auto-deactivate members who are no longer in the scraped data
+        # Auto-deactivate members who are no longer in the scraped data
         scraped_trainer_ids = set(scraped_data.keys())
-        await self._auto_deactivate_missing_members(scraped_trainer_ids)
+        await self._auto_deactivate_missing_members(club_id, scraped_trainer_ids)
         
-        # STEP 3: Process scraped data normally
+        # Process scraped data
         new_members = 0
         updated_members = 0
         
@@ -197,38 +177,34 @@ class QuotaCalculator:
             daily_fans = member_data["fans"]
             detected_join_day = member_data["join_day"]
             
-            # Get the latest cumulative count (last day in the array)
             if not daily_fans:
                 logger.warning(f"No fan data for {trainer_name}")
                 continue
             
-            cumulative_fans = daily_fans[-1]  # Last day's count
+            cumulative_fans = daily_fans[-1]
             
             # Look up member by trainer_id first, then by name
             if trainer_id:
-                member = await Member.get_by_trainer_id(trainer_id)
+                member = await Member.get_by_trainer_id(club_id, trainer_id)
             else:
-                member = await Member.get_by_name(trainer_name)
+                member = await Member.get_by_name(club_id, trainer_name)
             
             if not member:
-                # New member - calculate their join date based on detected_join_day
+                # New member
                 join_date = date(current_date.year, current_date.month, detected_join_day)
-                
-                member = await Member.create(trainer_name, join_date, trainer_id)
+                member = await Member.create(club_id, trainer_name, join_date, trainer_id)
                 new_members += 1
-                logger.info(f"New member added: {trainer_name} (ID: {trainer_id}, "
-                          f"joined Day {detected_join_day} = {join_date.strftime('%Y-%m-%d')})")
+                logger.info(f"New member added: {trainer_name} (ID: {trainer_id}, joined Day {detected_join_day})")
             else:
-                # Existing member - update name if it changed
+                # Existing member
                 if member.trainer_name != trainer_name:
                     await member.update_name(trainer_name)
                 
-                # Reactivate if they were previously deactivated
+                # Reactivate if they were previously deactivated (and not manually)
                 if not member.is_active:
-                    # UPDATED: Check if manually deactivated before reactivating
                     if member.manually_deactivated:
                         logger.info(f"Skipping reactivation of manually deactivated member: {trainer_name}")
-                        continue  # Skip processing this member entirely
+                        continue
                     else:
                         await member.activate()
                         logger.info(f"Reactivated returning member: {trainer_name}")
@@ -236,7 +212,7 @@ class QuotaCalculator:
             # Update last seen
             await member.update_last_seen(current_date)
             
-            # Calculate days active this month based on their join date
+            # Calculate days active this month
             if member.join_date.year == current_date.year and member.join_date.month == current_date.month:
                 join_day_from_db = member.join_date.day
             else:
@@ -245,7 +221,9 @@ class QuotaCalculator:
             days_active = self.calculate_days_active_in_month(join_day_from_db, current_day)
             
             # Calculate expected fans using dynamic quota system
-            expected_fans = await self.calculate_expected_fans(join_day_from_db, current_day, current_date)
+            expected_fans = await self.calculate_expected_fans(
+                club_id, join_day_from_db, current_day, current_date
+            )
             
             # Calculate deficit/surplus
             deficit_surplus = self.calculate_deficit_surplus(cumulative_fans, expected_fans)
@@ -256,6 +234,7 @@ class QuotaCalculator:
             # Create or update quota history
             await QuotaHistory.create(
                 member_id=member.member_id,
+                club_id=club_id,
                 date=current_date,
                 cumulative_fans=cumulative_fans,
                 expected_fans=expected_fans,
@@ -266,54 +245,45 @@ class QuotaCalculator:
             updated_members += 1
             
             logger.debug(f"{trainer_name}: {cumulative_fans:,} fans "
-                        f"(expected: {expected_fans:,} for {days_active} days, {deficit_surplus:+,})")
+                        f"(expected: {expected_fans:,}, {deficit_surplus:+,})")
         
-        logger.info(f"Processed {updated_members} members ({new_members} new)")
+        logger.info(f"Processed {updated_members} members ({new_members} new) for club {club_id}")
         return new_members, updated_members
     
-    async def _calculate_days_behind(self, member_id, current_deficit_surplus: int, current_date: date) -> int:
-        """
-        Calculate how many consecutive days a member has been behind
-        
-        Filter out today's date from history (in case /force_check runs multiple times)
-        Then count consecutive days before today that were behind
-        """
+    async def _calculate_days_behind(self, member_id: UUID, current_deficit_surplus: int, 
+                                    current_date: date) -> int:
+        """Calculate how many consecutive days a member has been behind"""
         if current_deficit_surplus >= 0:
             return 0
         
-        # Get recent history
         recent_history = await QuotaHistory.get_last_n_days(member_id, 10)
         
         if not recent_history:
-            # First day being behind
             return 1
         
-        # Filter out any records from TODAY
-        # (This happens when /force_check is run multiple times on the same day)
+        # Filter out any records from today
         recent_history = [h for h in recent_history if h.date < current_date]
         
-        # Count consecutive days with negative deficit BEFORE today
+        # Count consecutive days with negative deficit before today
         consecutive_days = 1  # Count today
         
-        # Now loop through past days (yesterday, 2 days ago, etc.)
         for history in recent_history:
             if history.deficit_surplus < 0:
                 consecutive_days += 1
             else:
-                # Found a day they were on track, stop counting
                 break
         
         logger.debug(f"Member {member_id}: {consecutive_days} consecutive days behind")
         return consecutive_days
     
-    async def get_member_status_summary(self, current_date: date) -> Dict:
+    async def get_member_status_summary(self, club_id: UUID, current_date: date) -> Dict:
         """
-        Get summary of all members' status
+        Get summary of all members' status for a club
         
         Returns:
             Dict with categorized member data
         """
-        members = await Member.get_all_active()
+        members = await Member.get_all_active(club_id)
         
         on_track = []
         behind = []

--- a/services/scrape_lock_manager.py
+++ b/services/scrape_lock_manager.py
@@ -1,0 +1,176 @@
+"""
+Scrape lock manager to prevent concurrent scraping conflicts
+"""
+from datetime import datetime, timedelta
+from typing import Optional
+from uuid import UUID
+import logging
+import asyncio
+
+from config.database import db
+
+logger = logging.getLogger(__name__)
+
+
+class ScrapeLockManager:
+    """Manages scraping locks to prevent concurrent scrapes"""
+    
+    LOCK_TIMEOUT_MINUTES = 30  # Auto-release locks older than 30 minutes
+    
+    @staticmethod
+    async def acquire_lock(club_id: UUID, locked_by: str = "bot") -> bool:
+        """
+        Try to acquire a scrape lock for a club
+        
+        Args:
+            club_id: Club UUID
+            locked_by: Identifier for who locked it
+        
+        Returns:
+            True if lock acquired, False if already locked
+        """
+        try:
+            # First, clean up stale locks
+            await ScrapeLockManager._cleanup_stale_locks()
+            
+            # Try to insert lock
+            query = """
+                INSERT INTO scrape_locks (club_id, locked_at, locked_by)
+                VALUES ($1, NOW(), $2)
+                ON CONFLICT (club_id) DO NOTHING
+                RETURNING club_id
+            """
+            result = await db.fetchrow(query, club_id, locked_by)
+            
+            if result:
+                logger.info(f"Acquired scrape lock for club {club_id}")
+                return True
+            else:
+                logger.warning(f"Could not acquire scrape lock for club {club_id} - already locked")
+                return False
+                
+        except Exception as e:
+            logger.error(f"Error acquiring scrape lock: {e}")
+            return False
+    
+    @staticmethod
+    async def release_lock(club_id: UUID):
+        """Release a scrape lock"""
+        try:
+            query = "DELETE FROM scrape_locks WHERE club_id = $1"
+            await db.execute(query, club_id)
+            logger.info(f"Released scrape lock for club {club_id}")
+        except Exception as e:
+            logger.error(f"Error releasing scrape lock: {e}")
+    
+    @staticmethod
+    async def is_locked(club_id: UUID) -> bool:
+        """Check if a club is currently locked"""
+        try:
+            # Clean up stale locks first
+            await ScrapeLockManager._cleanup_stale_locks()
+            
+            query = "SELECT club_id FROM scrape_locks WHERE club_id = $1"
+            result = await db.fetchval(query, club_id)
+            return result is not None
+        except Exception as e:
+            logger.error(f"Error checking scrape lock: {e}")
+            return False
+    
+    @staticmethod
+    async def get_lock_info(club_id: UUID) -> Optional[dict]:
+        """Get information about a lock"""
+        try:
+            query = """
+                SELECT club_id, locked_at, locked_by
+                FROM scrape_locks
+                WHERE club_id = $1
+            """
+            row = await db.fetchrow(query, club_id)
+            if row:
+                return dict(row)
+            return None
+        except Exception as e:
+            logger.error(f"Error getting lock info: {e}")
+            return None
+    
+    @staticmethod
+    async def wait_for_lock(club_id: UUID, locked_by: str = "bot", 
+                           max_wait_minutes: int = 10, check_interval: int = 30) -> bool:
+        """
+        Wait for a lock to become available
+        
+        Args:
+            club_id: Club UUID
+            locked_by: Identifier for who is waiting
+            max_wait_minutes: Maximum time to wait
+            check_interval: Seconds between checks
+        
+        Returns:
+            True if lock acquired, False if timeout
+        """
+        end_time = datetime.now() + timedelta(minutes=max_wait_minutes)
+        
+        while datetime.now() < end_time:
+            if await ScrapeLockManager.acquire_lock(club_id, locked_by):
+                return True
+            
+            logger.info(f"Waiting for scrape lock on club {club_id}...")
+            await asyncio.sleep(check_interval)
+        
+        logger.error(f"Timeout waiting for scrape lock on club {club_id}")
+        return False
+    
+    @staticmethod
+    async def _cleanup_stale_locks():
+        """Remove locks older than LOCK_TIMEOUT_MINUTES"""
+        try:
+            timeout_threshold = datetime.now() - timedelta(minutes=ScrapeLockManager.LOCK_TIMEOUT_MINUTES)
+            
+            query = """
+                DELETE FROM scrape_locks 
+                WHERE locked_at < $1
+                RETURNING club_id
+            """
+            result = await db.fetch(query, timeout_threshold)
+            
+            if result:
+                count = len(result)
+                logger.warning(f"Cleaned up {count} stale scrape lock(s)")
+                
+        except Exception as e:
+            logger.error(f"Error cleaning up stale locks: {e}")
+    
+    @staticmethod
+    async def force_release_all():
+        """Force release all locks (use with caution)"""
+        try:
+            query = "DELETE FROM scrape_locks"
+            await db.execute(query)
+            logger.warning("Force released all scrape locks")
+        except Exception as e:
+            logger.error(f"Error force releasing locks: {e}")
+
+
+class ScrapeContext:
+    """Context manager for scrape locks"""
+    
+    def __init__(self, club_id: UUID, locked_by: str = "bot"):
+        self.club_id = club_id
+        self.locked_by = locked_by
+        self.lock_acquired = False
+    
+    async def __aenter__(self):
+        """Acquire lock when entering context"""
+        self.lock_acquired = await ScrapeLockManager.acquire_lock(
+            self.club_id, self.locked_by
+        )
+        if not self.lock_acquired:
+            raise RuntimeError(f"Could not acquire scrape lock for club {self.club_id}")
+        return self
+    
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Release lock when exiting context"""
+        if self.lock_acquired:
+            await ScrapeLockManager.release_lock(self.club_id)
+        return False


### PR DESCRIPTION
Major Changes:
- Add clubs table and club management system (add/edit/remove/activate)
- Update all models (Member, QuotaHistory, Bomb, QuotaRequirement) with club_id filtering
- Refactor services (QuotaCalculator, BombManager, ReportGenerator) to accept club parameter
- Rewrite scheduled tasks for independent per-club scraping and reporting
- Add club autocomplete to all admin commands
- Implement scrape lock system to prevent concurrent club scrapes
- Add database migration logic for existing single-club deployments

Bug Fixes:
- Fix Days Active calculation using actual data count vs calendar days
- Fix monthly reset preserving join_date from previous month

New Commands:
- /add_club - Register new club with custom scrape URL
- /edit_club - Modify club settings (name, URL, channels, schedule)
- /remove_club - Delete club and all associated data
- /activate_club - Enable/disable club scraping
- /list_clubs - View all registered clubs

Migration:
- Existing data automatically migrated to 'Horsecore' club on first run
- Non-destructive migration preserves all members, history, and settings
- Backward compatible with single-club setups