### PR TITLE
Read administrator from the interaction, not the cached member

### DIFF
--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,0 +1,125 @@
+"""Tests for the manager permission checks.
+
+Built around one production incident: on 2026-08-05 a server administrator was
+refused ``/remove_club`` on guild 1426560692792317186 while Discord's own payload
+said he held administrator. ``is_admin`` was recomputing permissions from the
+cached member object, which resolves to base permissions whenever the cached
+guild is thin — silently turning an admin into a nobody.
+"""
+import asyncio
+from types import SimpleNamespace
+
+import discord
+import pytest
+
+from utils import permissions
+from utils.permissions import is_admin, is_full_manager
+
+GUILD = 1426560692932317186
+
+
+def interaction(*, payload_admin=False, member_admin=False, roles=(), guild=True):
+    """A stand-in interaction.
+
+    ``payload_admin`` is what Discord sent; ``member_admin`` is what discord.py
+    would recompute from cache. They are separate on purpose — the whole point is
+    what happens when they disagree.
+    """
+    user = SimpleNamespace(
+        id=1065273301896798328,
+        guild_permissions=discord.Permissions(administrator=member_admin),
+        roles=[SimpleNamespace(id=r) for r in roles],
+    )
+    return SimpleNamespace(
+        user=user,
+        guild_id=GUILD,
+        guild=SimpleNamespace(id=GUILD) if guild else None,
+        permissions=discord.Permissions(administrator=payload_admin),
+    )
+
+
+@pytest.fixture
+def no_manager_roles(monkeypatch):
+    """No role-based access, so only the admin path can grant anything."""
+    async def none(guild_id, role_ids):
+        return False
+
+    async def listing(guild_id):
+        return [GUILD]                       # the @everyone binding, as in prod
+    monkeypatch.setattr(permissions.GuildManagerRole, "has_any_role", none)
+    monkeypatch.setattr(permissions.GuildManagerRole, "get_role_ids", listing)
+
+
+class TestIsAdmin:
+    def test_trusts_the_permissions_discord_sent(self):
+        """The regression: cache says no, payload says yes. Payload wins."""
+        assert is_admin(interaction(payload_admin=True, member_admin=False)) is True
+
+    def test_still_accepts_a_cached_member_object(self):
+        """No payload permissions (older/edge contexts) — don't lose the admin."""
+        i = interaction(member_admin=True)
+        i.permissions = None
+        assert is_admin(i) is True
+
+    def test_non_admin_stays_denied(self):
+        assert is_admin(interaction()) is False
+
+    def test_agreement_is_unremarkable(self):
+        assert is_admin(interaction(payload_admin=True, member_admin=True)) is True
+
+
+class TestFullManager:
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    def test_the_incident(self, no_manager_roles):
+        """An admin whose roles came back empty must still be a full manager.
+
+        This is the exact shape logged in production: user_type=Member,
+        roles_seen=[], member_perms.admin=False, payload_perms.admin=True.
+        """
+        i = interaction(payload_admin=True, member_admin=False, roles=())
+        assert self._run(is_full_manager(i)) is True
+
+    def test_everyone_binding_grants_nothing_by_itself(self, no_manager_roles):
+        """@everyone is stripped before the lookup, so a non-admin holding only it
+        is denied — which is what made the success embed a false promise."""
+        i = interaction(roles=(GUILD,))
+        assert self._run(is_full_manager(i)) is False
+
+    def test_real_manager_role_still_works(self, monkeypatch):
+        async def has_role(guild_id, role_ids):
+            return 999 in role_ids
+        monkeypatch.setattr(permissions.GuildManagerRole, "has_any_role", has_role)
+        i = interaction(roles=(GUILD, 999))
+        assert self._run(is_full_manager(i)) is True
+
+    def test_plain_member_is_denied(self, no_manager_roles):
+        assert self._run(is_full_manager(interaction(roles=(GUILD, 42)))) is False
+
+
+class TestDenialLogging:
+    """Denials were silent, which is why the incident took a deploy to diagnose."""
+
+    def test_logs_both_permission_readings(self, no_manager_roles, caplog):
+        with caplog.at_level("INFO"):
+            asyncio.run(is_full_manager(interaction(roles=(GUILD,))))
+        msg = caplog.text
+        assert "Manager check DENIED" in msg
+        assert "member_perms.admin" in msg and "payload_perms.admin" in msg
+
+    def test_calls_out_an_everyone_binding(self, no_manager_roles, caplog):
+        with caplog.at_level("INFO"):
+            asyncio.run(is_full_manager(interaction(roles=(GUILD,))))
+        assert "can never match" in caplog.text
+
+    def test_logging_never_breaks_the_check(self, monkeypatch):
+        """A broken logger must not turn a denial into a crash mid-command."""
+        async def boom(guild_id):
+            raise RuntimeError("db down")
+        monkeypatch.setattr(permissions.GuildManagerRole, "get_role_ids", boom)
+
+        async def none(guild_id, role_ids):
+            return False
+        monkeypatch.setattr(permissions.GuildManagerRole, "has_any_role", none)
+        assert asyncio.run(is_full_manager(interaction(roles=(GUILD, 7)))) is False

--- a/utils/permissions.py
+++ b/utils/permissions.py
@@ -30,9 +30,30 @@ def _member_role_ids(interaction: discord.Interaction) -> List[int]:
 
 
 def is_admin(interaction: discord.Interaction) -> bool:
-    """True if the invoking member has Discord administrator in this guild."""
-    perms = getattr(interaction.user, 'guild_permissions', None)
-    return bool(perms and perms.administrator)
+    """True if the invoking member has Discord administrator in this guild.
+
+    Reads ``interaction.permissions`` — the permissions Discord computed and sent
+    with the interaction — rather than ``user.guild_permissions``, which discord.py
+    recomputes locally from the cached guild and member.
+
+    That local route fails open-ended: when the cached guild is a partial object
+    its role cache is empty and ``owner_id`` is unset, so every member resolves to
+    base permissions and administrator silently reads False. Measured 2026-08-05
+    on guild 1426560692932317186, where a server admin was refused ``/remove_club``
+    while ``interaction.permissions.administrator`` was True the whole time — the
+    same reading ``app_commands.checks.has_permissions`` uses, which is why the
+    admin-gated ``/add_manager_role`` had let him through minutes earlier.
+
+    Administrator cannot be revoked by channel overwrites, so the channel-resolved
+    permissions in the payload carry it faithfully.
+    """
+    perms = getattr(interaction, 'permissions', None)
+    if perms is not None and perms.administrator:
+        return True
+    # Fall back to the member object for any context that carries no payload
+    # permissions; it can only add a True, never mask one.
+    member_perms = getattr(interaction.user, 'guild_permissions', None)
+    return bool(member_perms and member_perms.administrator)
 
 
 async def is_full_manager(interaction: discord.Interaction) -> bool:


### PR DESCRIPTION
A server administrator was refused /remove_club on guild 1426560692932317186 while Discord's own payload said he held administrator the whole time. The denial log made it unambiguous:

  member_perms.admin=False payload_perms.admin=True roles_seen=[]

is_admin recomputed permissions from the cached guild and member. When that cached guild is a partial object its role cache is empty and owner_id is unset, so every member resolves to base permissions and administrator reads False - and the same thinness empties the role list, so the role-based half of the check fails at the same moment. Nothing distinguishes that from genuinely having no permissions.

It now reads interaction.permissions, which Discord computes and sends with the interaction. That is the reading app_commands.checks.has_permissions already uses, which is why the admin-gated /add_manager_role had let the same user through minutes before /remove_club refused him. Administrator cannot be revoked by channel overwrites, so the channel-resolved payload carries it faithfully. The member object stays as a fallback where no payload permissions exist; it can only add a True, never mask one.

Adds tests/test_permissions.py - the module had none. Covers the incident shape, the @everyone binding that grants nothing, and that a failure while logging a denial cannot crash the command.